### PR TITLE
Feature/Add support for domain-model 6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     "php": "^8.2",
     "ext-json": "*",
     "complex-heart/contracts": "^3.0.0",
-    "complex-heart/domain-model": "^5.0.0",
+    "complex-heart/domain-model": "^5.0.0 || ^6.0.0",
     "complex-heart/criteria": "^4.0.0",
     "complex-heart/domain-events": "^1.0.0"
   }


### PR DESCRIPTION
Widens the `complex-heart/domain-model` range to accept 6.x, so the SDK can pull the Illuminate 13 compatible line.

`criteria` needs no constraint change: `^4.0.0` already resolves to 4.3.0, which accepts domain-model 6. Verified that both 5.x and 6.x resolve cleanly.